### PR TITLE
Update PythonLanguage.kt to detect ".pyw"

### DIFF
--- a/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
+++ b/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
@@ -29,9 +29,10 @@ class PythonLanguage : Language {
     companion object {
 
         private const val FILE_EXTENSION = ".py"
+        private const val FILE_EXTENSION_ALT = ".pyw"
 
         fun supportFormat(fileName: String): Boolean {
-            return fileName.endsWith(FILE_EXTENSION, ignoreCase = true)
+            return fileName.endsWith(FILE_EXTENSION, ignoreCase = true) || fileName.endsWith(FILE_EXTENSION_ALT, ignoreCase = true)
         }
     }
 


### PR DESCRIPTION
Now it detects ".pyw" extension files (same as python file but the interpreter doesn't create a window).