### PR TITLE
Fixed python extensions

### DIFF
--- a/filesystems/filesystem-base/src/main/kotlin/com/brackeys/ui/filesystem/base/model/FileModel.kt
+++ b/filesystems/filesystem-base/src/main/kotlin/com/brackeys/ui/filesystem/base/model/FileModel.kt
@@ -30,7 +30,7 @@ data class FileModel(
         val TEXT = arrayOf(
             ".txt", ".js", ".json", ".java", ".kt", ".md", ".lua",
             ".as", ".cs", ".c", ".cpp", ".h", ".hpp", ".lisp", ".lsp",
-            ".cl", ".l", ".py", ".vb", ".bas", ".cls", ".sql", ".sqlite",
+            ".cl", ".l", ".py", ".pyw", ".pyi", ".vb", ".bas", ".cls", ".sql", ".sqlite",
             ".sqlite2", ".sqlite3", ".htm", ".html", ".xhtml", ".xht",
             ".xml", ".sh", ".ksh", ".bsh", ".csh", ".tcsh", ".zsh", ".bash",
             ".groovy", ".gvy", ".gy", ".gsh"

--- a/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
+++ b/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
@@ -31,7 +31,7 @@ class PythonLanguage : Language {
         private val FILE_EXTENSIONS = arrayOf(".py", ".pyw")
 
         fun supportFormat(fileName: String): Boolean {
-            return fileName.endsWith(FILE_EXTENSIONS, ignoreCase = true)
+            return fileName.endsWith(FILE_EXTENSIONS)
         }
     }
 

--- a/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
+++ b/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
@@ -31,7 +31,7 @@ class PythonLanguage : Language {
         private val FILE_EXTENSIONS = arrayOf(".py", ".pyw")
 
         fun supportFormat(fileName: String): Boolean {
-            return fileName.endsWith(FILE_EXTENSIONS)
+            return fileName.endsWith(FILE_EXTENSIONS, ignoreCase = true)
         }
     }
 

--- a/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
+++ b/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
@@ -28,10 +28,10 @@ class PythonLanguage : Language {
 
     companion object {
 
-        private const val FILE_EXTENSION = ".py"
+        private val FILE_EXTENSIONS = arrayOf(".py", ".pyw")
 
         fun supportFormat(fileName: String): Boolean {
-            return fileName.endsWith(FILE_EXTENSION, ignoreCase = true)
+            return fileName.endsWith(FILE_EXTENSIONS, , ignoreCase = true)
         }
     }
 

--- a/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
+++ b/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
@@ -31,7 +31,7 @@ class PythonLanguage : Language {
         private val FILE_EXTENSIONS = arrayOf(".py", ".pyw")
 
         fun supportFormat(fileName: String): Boolean {
-            return fileName.endsWith(FILE_EXTENSIONS, , ignoreCase = true)
+            return fileName.endsWith(FILE_EXTENSIONS, ignoreCase = true)
         }
     }
 

--- a/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
+++ b/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
@@ -29,7 +29,7 @@ class PythonLanguage : Language {
 
     companion object {
 
-        private val FILE_EXTENSIONS = arrayOf(".py", ".pyw")
+        private val FILE_EXTENSIONS = arrayOf(".py", ".pyw", ".pyi")
 
         fun supportFormat(fileName: String): Boolean {
             return fileName.endsWith(FILE_EXTENSIONS)

--- a/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
+++ b/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
@@ -20,6 +20,7 @@ import com.brackeys.ui.language.base.Language
 import com.brackeys.ui.language.base.parser.LanguageParser
 import com.brackeys.ui.language.base.provider.SuggestionProvider
 import com.brackeys.ui.language.base.styler.LanguageStyler
+import com.brackeys.ui.language.base.utils.endsWith
 import com.brackeys.ui.language.python.parser.PythonParser
 import com.brackeys.ui.language.python.provider.PythonProvider
 import com.brackeys.ui.language.python.styler.PythonStyler

--- a/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
+++ b/languages/language-python/src/main/kotlin/com/brackeys/ui/language/python/PythonLanguage.kt
@@ -32,7 +32,7 @@ class PythonLanguage : Language {
         private val FILE_EXTENSIONS = arrayOf(".py", ".pyw")
 
         fun supportFormat(fileName: String): Boolean {
-            return fileName.endsWith(FILE_EXTENSIONS, ignoreCase = true)
+            return fileName.endsWith(FILE_EXTENSIONS)
         }
     }
 


### PR DESCRIPTION
Added ".pyw", ".pyi" to the TEXT value of the FileModel class. Note that ".pyi" is not exactly a python file, but it is used as an Interface for Python modules.
Also used the arrayOf instead of different values in the
PythonLanguage.kt